### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       artifact-path: ${{ steps.build.outputs.out_dir }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/DataMedSci/rustoscope/security/code-scanning/1](https://github.com/DataMedSci/rustoscope/security/code-scanning/1)

To fix the issue, add a `permissions` key with minimal necessary privileges to either the workflow root (applies to all jobs) or specifically to the `build` job. Since the `build` job only checks out code, installs tools/deps, builds the project, and uploads an artifact—but does not require write access to repository contents, PRs, or any other resources—it's best to set its token permissions to `contents: read`. This can be done by adding the following block under the `build:` job declaration:
```yaml
permissions:
  contents: read
```
This ensures the `build` job (and only it) can read repository contents via the GitHub token and has no surplus privileges. _No other changes or dependencies are needed._

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
